### PR TITLE
Use ensure_resource for fix_services functionality

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -226,9 +226,7 @@ class tweaks (
     }
     validate_array($fix_services_services_real)
 
-    service { $fix_services_services_real :
-      enable => false,
-    }
+    ensure_resource('service', $fix_services_services_real, {'enable' => false})
   }
 
 # convert stringified booleans for fix_swappiness

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -428,17 +428,35 @@ describe 'tweaks' do
   end
 
   # <fix_services_services functionality>
-  describe 'with fix_services_services set to valid array on supported OS' do
-    let(:facts) { {
-      :osfamily          => 'Suse',
-      :lsbmajdistrelease => '11',
-    } }
-    let(:params) { {
-      :fix_services          => true,
-      :fix_services_services => ['stop','service'],
-    } }
-    ['stop','service'].each do |service|
-      it { should contain_service(service).with_enable('false') }
+  describe 'with fix_services_services set to valid array [\'servce1\', \'service2\']' do
+    let(:facts) do
+      {
+        :osfamily          => 'Suse',
+        :lsbmajdistrelease => '11',
+      }
+    end
+    let(:params) do
+      {
+        :fix_services          => true,
+        :fix_services_services => ['service1','service2'],
+      }
+    end
+
+    context 'on supported OS' do
+      ['service1','service2'].each do |service|
+        it { should contain_service(service).with_enable('false') }
+      end
+    end
+
+    context 'when \'service1\' resource already exists' do
+      let(:pre_condition) do
+        "service { 'service1': enable => false }"
+      end
+
+      it 'should not fail' do
+        should compile.with_all_deps
+      end
+      it { should contain_service('service2').with_enable('false') }
     end
   end
   # </fix_services_services functionality>


### PR DESCRIPTION
This should avoid double declaration errors if the service is managed elsewere already