### PR TITLE
Allow fix_updatedb to be used on Suse-11

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,6 @@ gem 'rspec-puppet'
 # rspec must be v2 for ruby 1.8.7
 if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
   gem 'rspec', '~> 2.0'
+  # rake >= 11 does not support ruby 1.8.7
+  gem 'rake', '~> 10.0'
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -95,7 +95,7 @@ class tweaks (
         }
       }
       default: {
-        fail('fix_localscratch is only supported on RedHat 5&6, Suse 10&11.')
+        fail('fix_localscratch is only supported on RedHat 5, 6 & 7, Suse 10, 11 & 12.')
       }
     }
   }
@@ -116,7 +116,7 @@ class tweaks (
         }
       }
       default: {
-        fail('fix_messages_permission is only supported on RedHat 5&6, Suse 10&11.')
+        fail('fix_messages_permission is only supported on RedHat 5, 6 & 7, Suse 10, 11 & 12.')
       }
     }
   }
@@ -248,7 +248,7 @@ class tweaks (
         }
       }
       default: {
-        fail('fix_swappiness is only supported on RedHat 5&6, Suse 10&11.')
+        fail('fix_swappiness is only supported on RedHat 5, 6 & 7, Suse 10, 11 & 12.')
       }
     }
   }
@@ -309,7 +309,7 @@ class tweaks (
         }
       }
       default: {
-        fail('fix_updatedb is only supported on Suse.')
+        fail('fix_updatedb is only supported on Suse 10, 11 & 12.')
       }
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -300,7 +300,7 @@ class tweaks (
 # Disable updatedb in /etc/sysconfig/locate
   if ( $fix_updatedb_real == true ) {
     case "${::osfamily}-${::lsbmajdistrelease}" {
-      'Suse-10', 'Suse-12': {
+      'Suse-10', 'Suse-11', 'Suse-12': {
         file_line { 'fix_updatedb':
           ensure => present,
           path   => '/etc/sysconfig/locate',
@@ -309,7 +309,7 @@ class tweaks (
         }
       }
       default: {
-        fail('fix_updatedb is only supported on Suse 10.')
+        fail('fix_updatedb is only supported on Suse.')
       }
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -141,7 +141,7 @@ describe 'tweaks' do
             it 'should fail' do
               expect {
                 should contain_class('tweaks')
-              }.to raise_error(Puppet::Error,/fix_localscratch is only supported on RedHat 5\&6, Suse 10\&11./)
+              }.to raise_error(Puppet::Error,/fix_localscratch is only supported on RedHat 5, 6 \& 7, Suse 10, 11 \& 12/)
             end
           end
         end
@@ -173,7 +173,7 @@ describe 'tweaks' do
             it 'should fail' do
               expect {
                 should contain_class('tweaks')
-              }.to raise_error(Puppet::Error,/fix_localscratch is only supported on RedHat 5\&6, Suse 10\&11./)
+              }.to raise_error(Puppet::Error,/fix_localscratch is only supported on RedHat 5, 6 \& 7, Suse 10, 11 \& 12/)
             end
           end
         end
@@ -201,7 +201,7 @@ describe 'tweaks' do
             it 'should fail' do
               expect {
                 should contain_class('tweaks')
-              }.to raise_error(Puppet::Error,/fix_messages_permission is only supported on RedHat 5\&6, Suse 10\&11./)
+              }.to raise_error(Puppet::Error,/fix_messages_permission is only supported on RedHat 5, 6 \& 7, Suse 10, 11 \& 12/)
             end
           end
         end
@@ -266,7 +266,7 @@ describe 'tweaks' do
             it 'should fail' do
               expect {
                 should contain_class('tweaks')
-              }.to raise_error(Puppet::Error,/fix_swappiness is only supported on RedHat 5\&6, Suse 10\&11./)
+              }.to raise_error(Puppet::Error,/fix_swappiness is only supported on RedHat 5, 6 \& 7, Suse 10, 11 \& 12/)
             end
           end
         end
@@ -296,7 +296,7 @@ describe 'tweaks' do
             it 'should fail' do
               expect {
                 should contain_class('tweaks')
-              }.to raise_error(Puppet::Error,/fix_swappiness is only supported on RedHat 5\&6, Suse 10\&11./)
+              }.to raise_error(Puppet::Error,/fix_swappiness is only supported on RedHat 5, 6 \& 7, Suse 10, 11 \& 12/)
             end
           end
         end
@@ -376,7 +376,7 @@ describe 'tweaks' do
             it 'should fail' do
               expect {
                 should contain_class('tweaks')
-              }.to raise_error(Puppet::Error,/fix_updatedb is only supported on Suse/)
+              }.to raise_error(Puppet::Error,/fix_updatedb is only supported on Suse 10, 11 \& 12/)
             end
           end
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,7 +25,7 @@ describe 'tweaks' do
       :servicelist => [ 'acpid', 'avahi-daemon', 'fbset', 'hotkey-setup', 'microcode', 'namcd', 'owcimomd', 'powersaved', 'smartd', 'smbfs', 'splash', 'splash_early', 'suse-blinux', 'xdm', ],
     },
     'Suse-11' =>  {
-      :os => 'Suse',    :rel => '11', :access_to_alsa => true,  :haldaemon => true,  :localscratch => true,  :messages_permission => true,  :services => true,  :swappiness => true,  :systohc_for_vm => true,  :updatedb => false, :xinetd => true,
+      :os => 'Suse',    :rel => '11', :access_to_alsa => true,  :haldaemon => true,  :localscratch => true,  :messages_permission => true,  :services => true,  :swappiness => true,  :systohc_for_vm => true,  :updatedb => true,  :xinetd => true,
       :servicelist => [ 'acpid', 'avahi-daemon', 'bluez-coldplug', 'boot.open-iscsi', 'fbset', 'libvirtd', 'microcode.ctl', 'namcd', 'network-remotefs', 'smartd', 'smbfs', 'splash', 'splash_early', 'xdm', ],
     },
     'Suse-12' =>  {
@@ -376,7 +376,7 @@ describe 'tweaks' do
             it 'should fail' do
               expect {
                 should contain_class('tweaks')
-              }.to raise_error(Puppet::Error,/fix_updatedb is only supported on Suse 10/)
+              }.to raise_error(Puppet::Error,/fix_updatedb is only supported on Suse/)
             end
           end
         end


### PR DESCRIPTION
Local team is starting to use the module in production more & more \o/

They investigated in the updatedb functionality on Suse-11 and requested that the module should take care for Suse-11 as well.

Additionally I have updated the error messages to be aligned with the supported OSfamilies again. Did forget that the last time :\

have phun & a nice weekend